### PR TITLE
Move fileName logic to a separate class

### DIFF
--- a/src/Converter/Pdf.php
+++ b/src/Converter/Pdf.php
@@ -7,6 +7,8 @@ use Knp\Snappy\Pdf as Converter;
  * PDF Converter
  *
  * @author Thiago Paes <mrprompt@gmail.com>
+ *
+ * @codeCoverageIgnore
  */
 class Pdf
 {

--- a/src/Shipment/FileNameCreator.php
+++ b/src/Shipment/FileNameCreator.php
@@ -1,0 +1,49 @@
+<?php
+
+
+namespace MrPrompt\BoletoCaixaEconomicaFederal\Shipment;
+
+use DateTime;
+use MrPrompt\ShipmentCommon\Base\Customer;
+use MrPrompt\ShipmentCommon\Base\Sequence;
+use MrPrompt\ShipmentCommon\Util\Number;
+
+/**
+ * Class FileNameCreator
+ * @package MrPrompt\BoletoCaixaEconomicaFederal\Shipment
+ */
+class FileNameCreator
+{
+    /**
+     * File name template
+     *
+     * @var string
+     */
+    const TEMPLATE_GENERATED = '{CLIENT}_{DDMMYYYY}_{SEQUENCE}.HTML';
+
+    /**
+     * @var array
+     */
+    private $search = [
+        '{CLIENT}',
+        '{DDMMYYYY}',
+        '{SEQUENCE}'
+    ];
+
+    /**
+     * @param Customer $customer
+     * @param Sequence $sequence
+     * @param DateTime $now
+     * @return mixed
+     */
+    public function create(Customer $customer, Sequence $sequence, DateTime $now)
+    {
+        $replace = [
+            Number::zeroFill($customer->getCode(), 6, Number::FILL_LEFT),
+            $now->format('dmY'),
+            Number::zeroFill($sequence->getValue(), 5, Number::FILL_LEFT),
+        ];
+
+        return str_replace($this->search, $replace, self::TEMPLATE_GENERATED);
+    }
+}

--- a/tests/Shipment/FileNameCreatorTest.php
+++ b/tests/Shipment/FileNameCreatorTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace MrPrompt\BoletoCaixaEconomicaFederal\Shipment;
+
+use DateTime;
+use Mockery as m;
+use MrPrompt\ShipmentCommon\Base\Customer;
+use MrPrompt\ShipmentCommon\Base\Sequence;
+use PHPUnit\Framework\TestCase;
+
+class FileNameCreatorTest extends TestCase
+{
+    /**
+     * @var FileNameCreator
+     */
+    private $fileNameCreator;
+
+    protected function setUp()
+    {
+        $this->fileNameCreator = new FileNameCreator();
+    }
+
+    /**
+     * @test
+     */
+    public function createFileNameBasedOnCustomerAndSequence()
+    {
+        $customer = m::mock(Customer::class);
+        $sequence = m::mock(Sequence::class);
+        $now = new DateTime("2019-09-04T09:00:00");
+
+        $customer->shouldReceive('getCode')->once()->andReturn(1);
+        $sequence->shouldReceive('getValue')->once()->andReturn(2);
+
+        $fileName = $this->fileNameCreator->create($customer, $sequence, $now);
+        $expectedFileName = '000001_04092019_00002.HTML';
+
+        $this->assertEquals($expectedFileName, $fileName);
+    }
+}


### PR DESCRIPTION
By doing this we:
- Remove duplicated code by moving file creation out of Billet and PaymentSlip
- Improve code coverage (it was not tested before)